### PR TITLE
Composer cannot find  igorw/config-service-provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/process": "2.1.*",
         "monolog/monolog": "1.2.*",
         "symfony/validator": "2.1.*",
-        "igorw/config-service-provider": "1.0",
+        "igorw/config-service-provider": "1.0.x-dev",
         "doctrine/dbal": "2.2.*"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
while installing via composer, got error:
`The requested package igorw/config-service-provider 1.0 could not be found.`

Composer version 1726fd4

So checked in packagist that package. Seems that now it had to be like:
`"igorw/config-service-provider": "1.0.x-dev",`
