### PR TITLE
Explode var is missing

### DIFF
--- a/src/boot.php
+++ b/src/boot.php
@@ -68,6 +68,7 @@ $business = scandir($businessDir);
 $arryToLoad = array();
 foreach ($business as $file){
 	if (pathinfo($file, PATHINFO_EXTENSION) === "php"){
+		$exploded = explode(".", $file);
 		$arryToLoad[strtolower($exploded[0])] = "Classes\\Business\\".$exploded[0];
 	}
 }


### PR DESCRIPTION
Explode var from file name is missing while loading business classes
The script loads the $exploded[0] from the route files
