### PR TITLE
Avoid "No route found for OPTIONS" errors

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -24,7 +24,7 @@ $app->before(function (Request $request) {
        $response->headers->set("Access-Control-Allow-Methods","GET,POST,PUT,DELETE,OPTIONS");
        $response->headers->set("Access-Control-Allow-Headers","Content-Type");
        $response->setStatusCode(200);
-       $response->send();
+       return $response->send();
    }
 }, Application::EARLY_EVENT);
 


### PR DESCRIPTION
To [short circuit  the Silex controller](http://silex.sensiolabs.org/doc/middlewares.html#short-circuiting-the-controller) we must return a Response and it seems calling $response->send() alone is not enough as it is generating an MethodNotAllowedHttpException.

The change proposed avoid these exceptions.
