### PR TITLE
Using a specific config based on the domain

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -6,7 +6,14 @@ define("ROOT_PATH", __DIR__ . "/..");
 
 $app = new Silex\Application();
 
-require __DIR__ . '/../resources/config/prod.php';
+switch ($_SERVER['SERVER_NAME']) {
+    case "localhost":
+        require __DIR__ . '/../resources/config/dev.php';
+        break;
+    default:
+        require __DIR__ . '/../resources/config/prod.php';
+        break;
+}
 
 require __DIR__ . '/../src/app.php';
 


### PR DESCRIPTION
When having several environments is usual to have specific configurations for each one of them. With this switch case, based in the server name, is being choosed which config file to use.